### PR TITLE
NullReferenceException が出るバグを修正します。

### DIFF
--- a/Assets/Scripts/UnityModule/Settings/Setting.cs
+++ b/Assets/Scripts/UnityModule/Settings/Setting.cs
@@ -48,7 +48,7 @@ namespace UnityModule.Settings {
         /// 設定を読み込む
         /// </summary>
         protected static void LoadSetting() {
-            instance = Resources.Load<T>(GetAssetName());
+            instance = Resources.Load<T>("Settings/" + GetAssetName());
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
* パスが深くなったので、 Resources.Load するときも深くしないとダメでした。