### PR TITLE
設定アセットが存在しない場合のエラーを解消する

### DIFF
--- a/Assets/Scripts/UnityModule/Settings/Setting.cs
+++ b/Assets/Scripts/UnityModule/Settings/Setting.cs
@@ -49,6 +49,10 @@ namespace UnityModule.Settings {
         /// </summary>
         protected static void LoadSetting() {
             instance = Resources.Load<T>("Settings/" + GetAssetName());
+            // もし、インスタンスが生成出来なかった (= アセットがない) 場合は、空のインスタンスを作る
+            if (instance == default(T)) {
+                instance = CreateInstance<T>();
+            }
         }
 
 #if UNITY_EDITOR

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "__PACKAGE_NAME__",
+  "name": "@umm/setting_core",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
* ランタイムで `Resources/Settings/` 以下に該当するアセットがない場合は空のインスタンスを生成して NullReferenceException の発生を抑制します