### PR TITLE
Fix failure to build

### DIFF
--- a/Assets/Scripts/UnityModule/Settings/SettingContainer.cs
+++ b/Assets/Scripts/UnityModule/Settings/SettingContainer.cs
@@ -35,8 +35,11 @@ namespace UnityModule.Settings
             instance
                 // Try to load from Resources
                 ?? (instance = Resources.Load<SettingContainer>(Path))
+#if UNITY_EDITOR
                 // Create empty instance
-                ?? (instance = CreateAsset());
+                ?? (instance = CreateAsset())
+#endif
+                ;
 
         [SerializeField] private List<Setting> settingList = new List<Setting>();
 


### PR DESCRIPTION
## What

* Fixes #14 
* 実機ビルド時はプリプロセッサマクロ `UNITY_EDITOR` が設定されないため、 `CreateAsset` メソッドが見付からなくなってしまう